### PR TITLE
add google analytics script

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,6 +2,16 @@
 <html>
 
 <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-125571662-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-125571662-1');
+  </script>
+
   <title>ESO Science Ambassadors</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
closes: https://github.com/cmharrison-astro/esoscienceambassadors/issues/19

- Adds the custom script to the webpage. 
- If the site is ever split across multiple pages, it will need to be added at the top of every page.
- It should be the first thing in the <head> tag (but I don't know why!)
- You should have been emailed with details to get onto the analytics account.
- We won't be able to see it working until the site is live.